### PR TITLE
Update pytest version and add license URL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
         features:
           - ansible-lint
           - pytest
-          - sshpass
         baseImage:
           - debian:latest
           - ubuntu:latest
@@ -39,7 +38,6 @@ jobs:
         features:
           - ansible-lint
           - pytest
-          - sshpass
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
         features:
           - ansible-lint
           - pytest
+          - sshpass
         baseImage:
           - debian:latest
           - ubuntu:latest
@@ -38,6 +39,7 @@ jobs:
         features:
           - ansible-lint
           - pytest
+          - sshpass
     steps:
       - uses: actions/checkout@v4
 

--- a/src/pytest/devcontainer-feature.json
+++ b/src/pytest/devcontainer-feature.json
@@ -1,29 +1,30 @@
 {
-    "id": "pytest",
-    "version": "1.0.1",
-    "name": "Pytest (via pipx)",
-    "documentationURL": "http://github.com/hspaans/devcontainers-features/tree/main/src/pytest",
-    "description": "The pytest framework makes it easy to write small tests, yet scales to support complex functional testing for applications and libraries.",
-    "options": {
-        "version": {
-            "default": "latest",
-            "description": "Select the version to install.",
-            "proposals": [
-                "latest"
-            ],
-            "type": "string"
-        },
-        "plugins": {
-            "default": "",
-            "description": "A space delimitered list of pytest plugins (will be injected into the pytest pipx env). see proposals for examples",
-            "proposals": [
-                "pytest-testinfra"
-            ],
-            "type": "string"
-        }
+  "id": "pytest",
+  "version": "1.0.2",
+  "name": "Pytest (via pipx)",
+  "documentationURL": "http://github.com/hspaans/devcontainers-features/tree/main/src/pytest",
+  "licenseURL": "http://github.com/hspaans/devcontainers-features/tree/main/LICENSE",
+  "description": "The pytest framework makes it easy to write small tests, yet scales to support complex functional testing for applications and libraries.",
+  "options": {
+    "version": {
+      "default": "latest",
+      "description": "Select the version to install.",
+      "proposals": [
+        "latest"
+      ],
+      "type": "string"
     },
-    "installsAfter": [
-        "ghcr.io/devcontainers-contrib/features/pipx-package",
-        "ghcr.io/devcontainers/features/python"
-    ]
+    "plugins": {
+      "default": "",
+      "description": "A space delimitered list of pytest plugins (will be injected into the pytest pipx env). see proposals for examples",
+      "proposals": [
+        "pytest-testinfra"
+      ],
+      "type": "string"
+    }
+  },
+  "installsAfter": [
+    "ghcr.io/devcontainers-contrib/features/pipx-package",
+    "ghcr.io/devcontainers/features/python"
+  ]
 }

--- a/test/pytest/scenarios.json
+++ b/test/pytest/scenarios.json
@@ -2,7 +2,7 @@
     "test": {
         "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
         "features": {
-            "pyest": {}
+            "pytest": {}
         }
     }
 }


### PR DESCRIPTION
This pull request updates the pytest version to 1.0.2 and adds a license URL to the pytest package.