### PR TITLE
Add a tool bundle from PyCQA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
           - pytest
           - pymarkdownlnt
           - pyupgrade
+          - pycqa
           - rstcheck
           - sshpass
         baseImage:
@@ -48,6 +49,7 @@ jobs:
           - pytest
           - pymarkdownlnt
           - pyupgrade
+          - pycqa
           - rstcheck
           - sshpass
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,8 @@ jobs:
           - mcr.microsoft.com/devcontainers/base:debian
           - mcr.microsoft.com/devcontainers/base:ubuntu
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout Code
+        uses: actions/checkout@v4
 
       - name: "Install latest devcontainer CLI"
         run: npm install -g @devcontainers/cli
@@ -53,7 +54,8 @@ jobs:
           - rstcheck
           - sshpass
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout Code
+        uses: actions/checkout@v4
 
       - name: "Install latest devcontainer CLI"
         run: npm install -g @devcontainers/cli
@@ -65,7 +67,8 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout Code
+        uses: actions/checkout@v4
 
       - name: "Install latest devcontainer CLI"
         run: npm install -g @devcontainers/cli

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,7 +8,8 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout Code
+        uses: actions/checkout@v4
 
       - name: "Validate devcontainer-feature.json files"
         uses: devcontainers/action@v1

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains following features:
 - [ansible-lint](./src/ansible-lint/README.md): Ansible Lint
 - [django-upgrade](./src/django-upgrade/README.md): Django-upgrade
 - [pyadr](./src/pyadr/README.md): Python ADR
+- [pycqa](./src/pycqa/README.md): PyCQA tools bundle
 - [pytest](./src/pytest/README.md): Pytest
 - [pymarkdownlnt](./src/pymarkdownlnt/README.md): PyMarkdownLinter
 - [pyupgrade](./src/pyupgrade/README.md): Pyupgrade

--- a/src/pycqa/README.md
+++ b/src/pycqa/README.md
@@ -1,0 +1,24 @@
+
+# Pyupgrade (via pipx) (pyupgrade)
+
+With pyupgrade you can automatically upgrade your Python code to a more modern version of Python.
+
+## Example Usage
+
+```json
+"features": {
+    "ghcr.io/hspaans/devcontainer-features/pyupgrade:1": {}
+}
+```
+
+## Options
+
+| Options Id | Description | Type | Default Value |
+|-----|-----|-----|-----|
+| version | Select the version to install. | string | latest |
+
+
+
+---
+
+_Note: This file was auto-generated from the [devcontainer-feature.json](https://github.com/hspaans/devcontainer-features/blob/main/src/pyupgrade/devcontainer-feature.json).  Add additional notes to a `NOTES.md`._

--- a/src/pycqa/devcontainer-feature.json
+++ b/src/pycqa/devcontainer-feature.json
@@ -1,0 +1,30 @@
+{
+  "id": "pycqa",
+  "version": "1.0.0",
+  "name": "PyCQA (via pipx)",
+  "documentationURL": "http://github.com/hspaans/devcontainer-features/tree/master/src/pycqa",
+  "licenseURL": "http://github.com/hspaans/devcontainer-features/tree/master/LICENSE",
+  "description": "Python Code Quality Authority tools.",
+  "options": {
+    "eradicate_version": {
+      "default": "latest",
+      "description": "Select the version to install.",
+      "proposals": [
+        "latest"
+      ],
+      "type": "string"
+    },
+    "isort_version": {
+      "default": "latest",
+      "description": "Select the version to install.",
+      "proposals": [
+        "latest"
+      ],
+      "type": "string"
+    }
+  },
+  "installsAfter": [
+    "ghcr.io/devcontainers-contrib/features/pipx-package",
+    "ghcr.io/devcontainers/features/python"
+  ]
+}

--- a/src/pycqa/devcontainer-feature.json
+++ b/src/pycqa/devcontainer-feature.json
@@ -1,14 +1,30 @@
 {
   "id": "pycqa",
   "version": "1.0.0",
-  "name": "PyCQA (via pipx)",
+  "name": "PyCQA tools bundle (via pipx)",
   "documentationURL": "http://github.com/hspaans/devcontainer-features/tree/master/src/pycqa",
   "licenseURL": "http://github.com/hspaans/devcontainer-features/tree/master/LICENSE",
   "description": "Python Code Quality Authority tools.",
   "options": {
+    "doc8_version": {
+      "default": "latest",
+      "description": "Select the version of doc8 to install.",
+      "proposals": [
+        "latest"
+      ],
+      "type": "string"
+    },
+    "docformatter_version": {
+      "default": "latest",
+      "description": "Select the version of docformatter to install.",
+      "proposals": [
+        "latest"
+      ],
+      "type": "string"
+    },
     "eradicate_version": {
       "default": "latest",
-      "description": "Select the version to install.",
+      "description": "Select the version of eradicate to install.",
       "proposals": [
         "latest"
       ],
@@ -16,7 +32,23 @@
     },
     "isort_version": {
       "default": "latest",
-      "description": "Select the version to install.",
+      "description": "Select the version of isort to install.",
+      "proposals": [
+        "latest"
+      ],
+      "type": "string"
+    },
+    "pydocstyle_version": {
+      "default": "latest",
+      "description": "Select the version of pydocstyle to install.",
+      "proposals": [
+        "latest"
+      ],
+      "type": "string"
+    },
+    "pyflakes_version": {
+      "default": "latest",
+      "description": "Select the version of pyflakes to install.",
       "proposals": [
         "latest"
       ],

--- a/src/pycqa/install.sh
+++ b/src/pycqa/install.sh
@@ -15,6 +15,18 @@ $nanolayer_location \
     install \
     devcontainer-feature \
     "ghcr.io/devcontainers-contrib/features/pipx-package:1.1.7" \
+    --option package='doc8' --option version="$DOC8_VERSION"
+
+$nanolayer_location \
+    install \
+    devcontainer-feature \
+    "ghcr.io/devcontainers-contrib/features/pipx-package:1.1.7" \
+    --option package='docformatter' --option version="$DOCFORMATTER_VERSION"
+
+$nanolayer_location \
+    install \
+    devcontainer-feature \
+    "ghcr.io/devcontainers-contrib/features/pipx-package:1.1.7" \
     --option package='eradicate' --option version="$ERADICATE_VERSION"
 
 $nanolayer_location \
@@ -23,5 +35,16 @@ $nanolayer_location \
     "ghcr.io/devcontainers-contrib/features/pipx-package:1.1.7" \
     --option package='isort' --option version="$ISORT_VERSION"
 
+$nanolayer_location \
+    install \
+    devcontainer-feature \
+    "ghcr.io/devcontainers-contrib/features/pipx-package:1.1.7" \
+    --option package='pydocstyle' --option version="$PYDOCSTYLE_VERSION"
+
+$nanolayer_location \
+    install \
+    devcontainer-feature \
+    "ghcr.io/devcontainers-contrib/features/pipx-package:1.1.7" \
+    --option package='pyflakes' --option version="$PYFLAKES_VERSION"
 
 echo 'Done!'

--- a/src/pycqa/install.sh
+++ b/src/pycqa/install.sh
@@ -1,0 +1,27 @@
+
+set -e
+
+. ./library_scripts.sh
+
+# nanolayer is a cli utility which keeps container layers as small as possible
+# source code: https://github.com/devcontainers-contrib/nanolayer
+# `ensure_nanolayer` is a bash function that will find any existing nanolayer installations,
+# and if missing - will download a temporary copy that automatically get deleted at the end
+# of the script
+ensure_nanolayer nanolayer_location "v0.5.0"
+
+
+$nanolayer_location \
+    install \
+    devcontainer-feature \
+    "ghcr.io/devcontainers-contrib/features/pipx-package:1.1.7" \
+    --option package='eradicate' --option version="$ERADICATE_VERSION"
+
+$nanolayer_location \
+    install \
+    devcontainer-feature \
+    "ghcr.io/devcontainers-contrib/features/pipx-package:1.1.7" \
+    --option package='isort' --option version="$ISORT_VERSION"
+
+
+echo 'Done!'

--- a/src/pycqa/library_scripts.sh
+++ b/src/pycqa/library_scripts.sh
@@ -1,0 +1,170 @@
+
+
+clean_download() {
+    # The purpose of this function is to download a file with minimal impact on container layer size
+    # this means if no valid downloader is found (curl or wget) then we install a downloader (currently wget) in a 
+    # temporary manner, and making sure to 
+    # 1. uninstall the downloader at the return of the function
+    # 2. revert back any changes to the package installer database/cache (for example apt-get lists)
+    # The above steps will minimize the leftovers being created while installing the downloader 
+    # Supported distros:
+    #  debian/ubuntu/alpine
+
+    url=$1
+    output_location=$2
+    tempdir=$(mktemp -d)
+    downloader_installed=""
+
+    _apt_get_install() {
+        tempdir=$1
+
+        # copy current state of apt list - in order to revert back later (minimize contianer layer size) 
+        cp -p -R /var/lib/apt/lists $tempdir 
+        apt-get update -y
+        apt-get -y install --no-install-recommends wget ca-certificates
+    }
+
+    _apt_get_cleanup() {
+        tempdir=$1
+
+        echo "removing wget"
+        apt-get -y purge wget --auto-remove
+
+        echo "revert back apt lists"
+        rm -rf /var/lib/apt/lists/*
+        rm -r /var/lib/apt/lists && mv $tempdir/lists /var/lib/apt/lists
+    }
+
+    _apk_install() {
+        tempdir=$1
+        # copy current state of apk cache - in order to revert back later (minimize contianer layer size) 
+        cp -p -R /var/cache/apk $tempdir 
+
+        apk add --no-cache  wget
+    }
+
+    _apk_cleanup() {
+        tempdir=$1
+
+        echo "removing wget"
+        apk del wget 
+    }
+    # try to use either wget or curl if one of them already installer
+    if type curl >/dev/null 2>&1; then
+        downloader=curl
+    elif type wget >/dev/null 2>&1; then
+        downloader=wget
+    else
+        downloader=""
+    fi
+
+    # in case none of them is installed, install wget temporarly
+    if [ -z $downloader ] ; then
+        if [ -x "/usr/bin/apt-get" ] ; then
+            _apt_get_install $tempdir
+        elif [ -x "/sbin/apk" ] ; then
+            _apk_install $tempdir
+        else
+            echo "distro not supported"
+            exit 1
+        fi
+        downloader="wget"
+        downloader_installed="true"
+    fi
+
+    if [ $downloader = "wget" ] ; then
+        wget -q $url -O $output_location
+    else
+        curl -sfL $url -o $output_location 
+    fi
+
+    # NOTE: the cleanup procedure was not implemented using `trap X RETURN` only because
+    # alpine lack bash, and RETURN is not a valid signal under sh shell
+    if ! [ -z $downloader_installed  ] ; then
+        if [ -x "/usr/bin/apt-get" ] ; then
+            _apt_get_cleanup $tempdir
+        elif [ -x "/sbin/apk" ] ; then
+            _apk_cleanup $tempdir
+        else
+            echo "distro not supported"
+            exit 1
+        fi
+    fi 
+
+}
+
+
+ensure_nanolayer() {
+    # Ensure existance of the nanolayer cli program
+    local variable_name=$1
+
+    local required_version=$2
+
+    local __nanolayer_location=""
+
+    # If possible - try to use an already installed nanolayer
+    if [ -z "${NANOLAYER_FORCE_CLI_INSTALLATION}" ]; then
+        if [ -z "${NANOLAYER_CLI_LOCATION}" ]; then
+            if type nanolayer >/dev/null 2>&1; then
+                echo "Found a pre-existing nanolayer in PATH"
+                __nanolayer_location=nanolayer
+            fi
+        elif [ -f "${NANOLAYER_CLI_LOCATION}" ] && [ -x "${NANOLAYER_CLI_LOCATION}" ] ; then
+            __nanolayer_location=${NANOLAYER_CLI_LOCATION}
+            echo "Found a pre-existing nanolayer which were given in env variable: $__nanolayer_location"
+        fi
+
+        # make sure its of the required version
+        if ! [ -z "${__nanolayer_location}" ]; then
+            local current_version
+            current_version=$($__nanolayer_location --version)
+
+
+            if ! [ $current_version == $required_version ]; then
+                echo "skipping usage of pre-existing nanolayer. (required version $required_version does not match existing version $current_version)"
+                __nanolayer_location=""
+            fi
+        fi
+
+    fi
+
+    # If not previuse installation found, download it temporarly and delete at the end of the script 
+    if [ -z "${__nanolayer_location}" ]; then
+
+        if [ "$(uname -sm)" = 'Linux x86_64' ] || [ "$(uname -sm)" = "Linux aarch64" ]; then
+            tmp_dir=$(mktemp -d -t nanolayer-XXXXXXXXXX)
+
+            clean_up () {
+                ARG=$?
+                rm -rf $tmp_dir
+                exit $ARG
+            }
+            trap clean_up EXIT
+
+            
+            if [ -x "/sbin/apk" ] ; then
+                clib_type=musl
+            else
+                clib_type=gnu
+            fi
+
+            tar_filename=nanolayer-"$(uname -m)"-unknown-linux-$clib_type.tgz
+
+            # clean download will minimize leftover in case a downloaderlike wget or curl need to be installed
+            clean_download https://github.com/devcontainers-contrib/cli/releases/download/$required_version/$tar_filename $tmp_dir/$tar_filename
+            
+            tar xfzv $tmp_dir/$tar_filename -C "$tmp_dir"
+            chmod a+x $tmp_dir/nanolayer
+            __nanolayer_location=$tmp_dir/nanolayer
+      
+
+        else
+            echo "No binaries compiled for non-x86-linux architectures yet: $(uname -m)"
+            exit 1
+        fi
+    fi
+
+    # Expose outside the resolved location
+    export ${variable_name}=$__nanolayer_location
+
+}

--- a/test/pycqa/scenarios.json
+++ b/test/pycqa/scenarios.json
@@ -1,0 +1,8 @@
+{
+    "test": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "pycqa": {}
+        }
+    }
+}

--- a/test/pycqa/test.sh
+++ b/test/pycqa/test.sh
@@ -4,7 +4,12 @@ set -e
 
 source dev-container-features-test-lib
 
+check "doc8 --version" doc8 --version
+check "docformatter --version" docformatter --version
 check "eradicate --version" eradicate --version
 check "isort --version" isort --version
+check "pydocstyle --version" pydocstyle --version
+check "pyflakes --version" pyflakes --version
+
 
 reportResults

--- a/test/pycqa/test.sh
+++ b/test/pycqa/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -i
+
+set -e
+
+source dev-container-features-test-lib
+
+check "eradicate --version" eradicate --version
+check "isort --version" isort --version
+
+reportResults


### PR DESCRIPTION
Bundle all PyCQA tool in one bundle with exception for flake8 and bandit for now.

Tools:
-  [PyCQA/doc8](https://github.com/PyCQA/doc8)
-  [PyCQA/docformatter](https://github.com/PyCQA/docformatter)
-  [PyCQA/eradicate](https://github.com/PyCQA/eradicate)
-  [PyCQA/isort](https://github.com/PyCQA/isort)
-  [PyCQA/pydocstyle](https://github.com/PyCQA/pydocstyle)
-  [PyCQA/pyflakes](https://github.com/PyCQA/pyflakes)
