### PR TITLE
Update Ansible Lint to version 2.0.0 and adjust dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Contents
 
 This repository contains following features:
+
 - [ansible-lint](./src/ansible-lint/README.md): Ansible Lint
 - [django-upgrade](./src/django-upgrade/README.md): Django-upgrade
 - [pyadr](./src/pyadr/README.md): Python ADR

--- a/src/ansible-lint/README.md
+++ b/src/ansible-lint/README.md
@@ -7,7 +7,7 @@ ansible-lint checks playbooks for practices and behavior that could potentially 
 
 ```json
 "features": {
-    "ghcr.io/hspaans/devcontainer-features/ansible-lint:1": {}
+    "ghcr.io/hspaans/devcontainer-features/ansible-lint:2": {}
 }
 ```
 

--- a/src/ansible-lint/devcontainer-feature.json
+++ b/src/ansible-lint/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "ansible-lint",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "name": "Ansible Lint (via pipx)",
   "documentationURL": "http://github.com/hspaans/devcontainer-features/tree/master/src/ansible-lint",
   "licenseURL": "http://github.com/hspaans/devcontainer-features/tree/master/LICENSE",
@@ -22,8 +22,8 @@
     }
   },
   "installsAfter": [
-    "ghcr.io/devcontainers-contrib/features/pipx-package",
+    "ghcr.io/devcontainers-extra/features/pipx-package",
     "ghcr.io/devcontainers/features/python",
-    "ghcr.io/devcontainers-contrib/features/ansible"
+    "ghcr.io/devcontainers-extra/features/ansible"
   ]
 }

--- a/src/ansible-lint/install.sh
+++ b/src/ansible-lint/install.sh
@@ -14,7 +14,7 @@ ensure_nanolayer nanolayer_location "v0.5.0"
 $nanolayer_location \
     install \
     devcontainer-feature \
-    "ghcr.io/devcontainers-contrib/features/pipx-package:1.1.7" \
+    "ghcr.io/devcontainers-extra/features/pipx-package:1.1.9" \
     --option package='ansible-lint' --option injections="$PLUGINS" --option version="$VERSION"
 
 


### PR DESCRIPTION
Upgrade Ansible Lint to version 2.0.0 and modify related dependencies to ensure compatibility. Adjust the feature references in the configuration files accordingly.