### PR TITLE
fix: clean up `sshpass`

### DIFF
--- a/src/sshpass/README.md
+++ b/src/sshpass/README.md
@@ -1,25 +1,20 @@
 
 # sshpass (sshpass)
 
-Installs the GitHub CLI. Auto-detects latest version and installs needed dependencies.
+`sshpass` is a tool for non-interactivly performing password authentication with SSH's so called "interactive keyboard password authentication".
 
 ## Example Usage
 
 ```json
 "features": {
-    "ghcr.io/hspaans/devcontainer-features/sshpass:1": {}
+    "ghcr.io/devcontainer-features/sshpass:1": {}
 }
 ```
 
-## Options
 
-| Options Id | Description | Type | Default Value |
-|-----|-----|-----|-----|
-| version | Select version of the GitHub CLI, if not latest. | string | latest |
-| installDirectlyFromGitHubRelease | - | boolean | true |
 
 
 
 ---
 
-_Note: This file was auto-generated from the [devcontainer-feature.json](https://github.com/hspaans/devcontainer-features/blob/main/src/sshpass/devcontainer-feature.json).  Add additional notes to a `NOTES.md`._
+_Note: This file was auto-generated from the [devcontainer-feature.json](devcontainer-feature.json).  Add additional notes to a `NOTES.md`._

--- a/src/sshpass/devcontainer-feature.json
+++ b/src/sshpass/devcontainer-feature.json
@@ -2,24 +2,9 @@
   "id": "sshpass",
   "version": "1.0.1",
   "name": "sshpass",
-  "documentationURL": "https://github.com/hspaans/devcontainer-features/tree/master/src/github-cli",
+  "documentationURL": "https://github.com/hspaans/devcontainer-features/tree/master/src/sshpass",
   "licenseURL": "http://github.com/hspaans/devcontainer-features/tree/master/LICENSE",
-  "description": "Installs the GitHub CLI. Auto-detects latest version and installs needed dependencies.",
-  "options": {
-    "version": {
-      "type": "string",
-      "proposals": [
-        "latest",
-        "none"
-      ],
-      "default": "latest",
-      "description": "Select version of the GitHub CLI, if not latest."
-    },
-    "installDirectlyFromGitHubRelease": {
-      "type": "boolean",
-      "default": true
-    }
-  },
+  "description": "`sshpass` is a tool for non-interactivly performing password authentication with SSH's so called \"interactive keyboard password authentication\".",
   "installsAfter": [
     "ghcr.io/devcontainers/features/common-utils"
   ]


### PR DESCRIPTION
Hey there 👋🏼 

Found some small issues with the `sshpass` feature so decided to make a PR:
- Fixed the description (taken from [SourceForge](https://sourceforge.net/projects/sshpass/))
- Removed options, as that also seems leftover from copying the GitHub CLI feature but unused
- Autogenerated docs again after making changes 